### PR TITLE
Migrate extension to Manifest V3

### DIFF
--- a/YouWork_Extension/background.js
+++ b/YouWork_Extension/background.js
@@ -1,47 +1,53 @@
-var paused_youwork;
+const TOGGLE_MENU_ID = "youwork-toggle";
+const ICON_PATH = "img/icon_128.png";
 
-chrome.storage.local.get('youwork_is_paused', function (result) {
-    if (result.youwork_is_paused === true) {
-        console.log("YouWork paused. Redirect disabled.");
-    } else {
+function ensureContextMenu() {
+    chrome.contextMenus.removeAll(() => {
+        chrome.contextMenus.create({
+            id: TOGGLE_MENU_ID,
+            title: "Pause/Resume YouWork",
+            contexts: ["action"],
+        });
+    });
+}
 
-        var currentUrl = location.href;
-        var redirectUrl = "https://tash-had.github.io/YouWork";
+function showNotification(message) {
+    chrome.notifications.create({
+        type: "basic",
+        iconUrl: ICON_PATH,
+        title: "YouWork",
+        message,
+    });
+}
 
-        var regExp = /^.*(youtu\.be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/;
-        var match = currentUrl.match(regExp);
-        if (match && match[2].length == 11) {
-            var videoId = match[2];
-            redirectUrl = redirectUrl + "?videoId=" + videoId; 
-        }
+ensureContextMenu();
 
-        window.location = redirectUrl;
-    }
+chrome.runtime.onInstalled.addListener(() => {
+    ensureContextMenu();
 });
 
-try {
-    chrome.contextMenus.removeAll();
-    chrome.contextMenus.create({
-        title: "Pause/Resume YouWork",
-        contexts: ["browser_action"],
-        onclick: function () {
-            chrome.storage.local.get('youwork_is_paused', function (result) {
-                paused_youwork = result.youwork_is_paused;
-                if (paused_youwork == true) {
-                    chrome.storage.local.set({
-                        'youwork_is_paused': false
-                    }, function () {
-                        alert("YouWork Resumed. If YouTube is open, refresh it.");
-                    });
-                } else {
-                    chrome.storage.local.set({
-                        'youwork_is_paused': true
-                    }, function () {
-                        alert("YouWork Paused.");
-                    });
-                }
-            });
+chrome.runtime.onStartup.addListener(() => {
+    ensureContextMenu();
+});
 
-        }
+chrome.contextMenus.onClicked.addListener((info) => {
+    if (info.menuItemId !== TOGGLE_MENU_ID) {
+        return;
+    }
+
+    chrome.storage.local.get("youwork_is_paused", (result) => {
+        const paused = result.youwork_is_paused === true;
+        const newValue = !paused;
+        chrome.storage.local.set({ youwork_is_paused: newValue }, () => {
+            if (chrome.runtime.lastError) {
+                console.error("Failed to update pause state", chrome.runtime.lastError);
+                return;
+            }
+
+            const message = newValue
+                ? "YouWork Paused."
+                : "YouWork Resumed. If YouTube is open, refresh it.";
+            showNotification(message);
+        });
     });
-} catch (err) { }
+});

--- a/YouWork_Extension/contentScript.js
+++ b/YouWork_Extension/contentScript.js
@@ -1,0 +1,18 @@
+chrome.storage.local.get("youwork_is_paused", (result) => {
+    if (result.youwork_is_paused === true) {
+        console.log("YouWork paused. Redirect disabled.");
+        return;
+    }
+
+    const currentUrl = window.location.href;
+    let redirectUrl = "https://tash-had.github.io/YouWork";
+
+    const regExp = /^.*(youtu\.be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/;
+    const match = currentUrl.match(regExp);
+    if (match && match[2].length === 11) {
+        const videoId = match[2];
+        redirectUrl = `${redirectUrl}?videoId=${videoId}`;
+    }
+
+    window.location.href = redirectUrl;
+});

--- a/YouWork_Extension/manifest.json
+++ b/YouWork_Extension/manifest.json
@@ -3,21 +3,23 @@
     "description": "Prevent YouTube distractions.",
     "version": "1.3",
     "permissions": [
-        "activeTab",
         "contextMenus",
-        "storage"
+        "storage",
+        "notifications"
     ],
     "background": {
-        "scripts": ["background.js"]
+        "service_worker": "background.js"
     },
-    "content_scripts": [{
-        "matches": ["https://www.youtube.com/*"],
-        "exclude_matches": ["https://www.youtube.com/embed/*"],
-        "js": ["background.js"],
-        "run_at": "document_start",
-        "all_frames": true
-    }],
-    "browser_action": {
+    "content_scripts": [
+        {
+            "matches": ["https://www.youtube.com/*"],
+            "exclude_matches": ["https://www.youtube.com/embed/*"],
+            "js": ["contentScript.js"],
+            "run_at": "document_start",
+            "all_frames": true
+        }
+    ],
+    "action": {
         "default_popup": "popup.html"
     },
     "icons": {
@@ -26,5 +28,5 @@
         "48": "img/icon_48.png",
         "128": "img/icon_128.png"
     },
-    "manifest_version": 2
+    "manifest_version": 3
 }


### PR DESCRIPTION
## Summary
- update the extension manifest to version 3 and configure the background service worker
- move the redirect logic into a dedicated content script for YouTube pages
- replace alert messaging with notifications when toggling the pause state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d767577800832fa99271f5320dc7b2